### PR TITLE
Proximal Quasi Newton added

### DIFF
--- a/R/ADMM.R
+++ b/R/ADMM.R
@@ -262,7 +262,8 @@ ADMM <- function( x,
                   tol_rel_gap = 1e-5,
                   tol_infeas = 1e-3,
                   tol_abs = tol_abs,
-                  tol_rel = tol_rel)
+                  tol_rel = tol_rel,
+                  tol = 1e-10)
 
   fitADMM <- if (is_sparse) sparseADMM else denseADMM
 

--- a/R/ADMM.R
+++ b/R/ADMM.R
@@ -263,7 +263,7 @@ ADMM <- function( x,
                   tol_infeas = 1e-3,
                   tol_abs = tol_abs,
                   tol_rel = tol_rel,
-                  tol = 1e-10)
+                  tol_coef = 1e-10)
 
   fitADMM <- if (is_sparse) sparseADMM else denseADMM
 

--- a/R/FISTA.R
+++ b/R/FISTA.R
@@ -258,7 +258,7 @@ FISTA <- function(x,
                   tol_infeas = tol_infeas,
                   tol_abs = 1e-5,
                   tol_rel = 1e-4,
-                  tol = 1e-10)
+                  tol_coef = 1e-10)
 
   fitFISTA <- if (is_sparse) sparseFISTA else denseFISTA
 

--- a/R/FISTA.R
+++ b/R/FISTA.R
@@ -257,7 +257,8 @@ FISTA <- function(x,
                   tol_rel_gap = tol_rel_gap,
                   tol_infeas = tol_infeas,
                   tol_abs = 1e-5,
-                  tol_rel = 1e-4)
+                  tol_rel = 1e-4,
+                  tol = 1e-10)
 
   fitFISTA <- if (is_sparse) sparseFISTA else denseFISTA
 

--- a/R/PN.R
+++ b/R/PN.R
@@ -78,6 +78,7 @@ PN <- function(x,
                tol_dev_change = 1e-5,
                tol_dev_ratio = 0.995,
                max_variables = NROW(x),
+               hessian_calc = c("lbfgs", "exact"),
                max_passes = 150,
                diagnostics =  FALSE,
                verbosity = 0
@@ -86,6 +87,7 @@ PN <- function(x,
   ocall <- match.call()
 
   family <- match.arg(family)
+  hessian_calc <- match.arg(hessian_calc)
   screen_alg <- match.arg(screen_alg)
 
   if (is.character(scale)) {
@@ -246,6 +248,7 @@ PN <- function(x,
                   diagnostics = diagnostics,
                   verbosity = verbosity,
                   max_variables = max_variables,
+                  hessian_calc = hessian_calc,
                   tol_dev_change = tol_dev_change,
                   tol_dev_ratio = tol_dev_ratio,
                   tol_rel_gap = 1e-5,

--- a/R/PN.R
+++ b/R/PN.R
@@ -83,7 +83,7 @@ PN <- function(x,
                tol_dev_ratio = 0.995,
                max_variables = NROW(x),
                hessian_calc = c("lbfgs", "exact"),
-               max_passes = if (hessian_calc == "exact") 150 else 400,
+               max_passes = if (hessian_calc == "exact") 500 else 3000,
                tol = 1e-10,
                diagnostics =  FALSE,
                verbosity = 0

--- a/R/PN.R
+++ b/R/PN.R
@@ -35,6 +35,9 @@
 #' @param q parameter controlling the shape of the lambda sequence, with
 #'   usage varying depending on the type of path used and has no effect
 #'   is a custom `lambda` sequence is used.
+#' @param hessian_calc Method to use for Hessian caluclation. 
+#'   - `"exact"` No approximations will be made.
+#'   - `"lbfgs"` Updates will be made using L-BFGS.
 #' @param max_passes maximum number of passes (outer iterations) for solver
 #' @param diagnostics whether to save diagnostics from the solver
 #'   (timings and other values depending on type of solver)
@@ -50,6 +53,7 @@
 #'     no violations in the strong set
 #' @param verbosity level of verbosity for displaying output from the
 #'   program. Not completely developed. Use 3 just for now.
+#' @param tol Tolerance to use for change in L2 norm of variable 
 #' @param tol_dev_change the regularization path is stopped if the
 #'   fractional change in deviance falls below this value; note that this is
 #'   automatically set to 0 if a alpha is manually entered

--- a/R/PN.R
+++ b/R/PN.R
@@ -79,7 +79,8 @@ PN <- function(x,
                tol_dev_ratio = 0.995,
                max_variables = NROW(x),
                hessian_calc = c("lbfgs", "exact"),
-               max_passes = 150,
+               max_passes = if (hessian_calc == "exact") 150 else 400,
+               tol = 1e-10,
                diagnostics =  FALSE,
                verbosity = 0
 ) {
@@ -113,7 +114,8 @@ PN <- function(x,
     is.finite(max_passes),
     is.logical(diagnostics),
     is.logical(intercept),
-    is.logical(center)
+    is.logical(center),
+    tol >= 0
   )
 
   fit_intercept <- intercept
@@ -254,7 +256,8 @@ PN <- function(x,
                   tol_rel_gap = 1e-5,
                   tol_infeas = 1e-3,
                   tol_abs = 1e-5,
-                  tol_rel = 1e-4)
+                  tol_rel = 1e-4,
+                  tol = tol)
 
   fitPN <- if (is_sparse) sparsePN else densePN
 

--- a/R/PN.R
+++ b/R/PN.R
@@ -53,7 +53,7 @@
 #'     no violations in the strong set
 #' @param verbosity level of verbosity for displaying output from the
 #'   program. Not completely developed. Use 3 just for now.
-#' @param tol Tolerance to use for change in L2 norm of variable 
+#' @param tol_coef Tolerance to use for change in L2 norm of variable 
 #' @param tol_dev_change the regularization path is stopped if the
 #'   fractional change in deviance falls below this value; note that this is
 #'   automatically set to 0 if a alpha is manually entered
@@ -84,7 +84,7 @@ PN <- function(x,
                max_variables = NROW(x),
                hessian_calc = c("lbfgs", "exact"),
                max_passes = if (hessian_calc == "exact") 500 else 3000,
-               tol = 1e-10,
+               tol_coef = 1e-10,
                diagnostics =  FALSE,
                verbosity = 0
 ) {
@@ -119,7 +119,7 @@ PN <- function(x,
     is.logical(diagnostics),
     is.logical(intercept),
     is.logical(center),
-    tol >= 0
+    tol_coef >= 0
   )
 
   fit_intercept <- intercept
@@ -261,7 +261,7 @@ PN <- function(x,
                   tol_infeas = 1e-3,
                   tol_abs = 1e-5,
                   tol_rel = 1e-4,
-                  tol = tol)
+                  tol_coef = tol_coef)
 
   fitPN <- if (is_sparse) sparsePN else densePN
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,14 +1,14 @@
 #' Code borrowed from SLOPE package for generating datasets
 #' @param n Number of data points
 #' @param p Number of features
-#' @param q <TODO>
-#' @param n_groups <TODO>
-#' @param n_targets <TODO>
+#' @param q Parameter controlling lambda sequence
+#' @param n_groups Number of groups of predictors
+#' @param n_targets Dimension of response variable
 #' @param density Determine sparsity of the data generated. Default set to 0.
-#' @param amplitude <TODO>
-#' @param alpha <TODO>
+#' @param amplitude Scale of coefficient in output
+#' @param alpha Standard deviation
 #' @param response Choice of likelohood function
-#' @param rho <TODO>
+#' @param rho Correlation
 #' @export
 randomProblem <-
   function(n = 1000,

--- a/man/PN.Rd
+++ b/man/PN.Rd
@@ -22,8 +22,8 @@ PN(
   tol_dev_ratio = 0.995,
   max_variables = NROW(x),
   hessian_calc = c("lbfgs", "exact"),
-  max_passes = if (hessian_calc == "exact") 150 else 400,
-  tol = 1e-10,
+  max_passes = if (hessian_calc == "exact") 500 else 3000,
+  tol_coef = 1e-10,
   diagnostics = FALSE,
   verbosity = 0
 )
@@ -116,7 +116,7 @@ the number of levels of the response minus one.}
 
 \item{max_passes}{maximum number of passes (outer iterations) for solver}
 
-\item{tol}{Tolerance to use for change in L2 norm of variable}
+\item{tol_coef}{Tolerance to use for change in L2 norm of variable}
 
 \item{diagnostics}{whether to save diagnostics from the solver
 (timings and other values depending on type of solver)}

--- a/man/PN.Rd
+++ b/man/PN.Rd
@@ -21,7 +21,9 @@ PN(
   tol_dev_change = 1e-05,
   tol_dev_ratio = 0.995,
   max_variables = NROW(x),
-  max_passes = 150,
+  hessian_calc = c("lbfgs", "exact"),
+  max_passes = if (hessian_calc == "exact") 150 else 400,
+  tol = 1e-10,
   diagnostics = FALSE,
   verbosity = 0
 )
@@ -106,7 +108,15 @@ maximum number of unique, nonzero coefficients in absolute value in model.
 For the multinomial family, this value will be multiplied internally with
 the number of levels of the response minus one.}
 
+\item{hessian_calc}{Method to use for Hessian caluclation.
+\itemize{
+\item \code{"exact"} No approximations will be made.
+\item \code{"lbfgs"} Updates will be made using L-BFGS.
+}}
+
 \item{max_passes}{maximum number of passes (outer iterations) for solver}
+
+\item{tol}{Tolerance to use for change in L2 norm of variable}
 
 \item{diagnostics}{whether to save diagnostics from the solver
 (timings and other values depending on type of solver)}

--- a/man/randomProblem.Rd
+++ b/man/randomProblem.Rd
@@ -22,21 +22,21 @@ randomProblem(
 
 \item{p}{Number of features}
 
-\item{q}{<TODO>}
+\item{q}{Parameter controlling lambda sequence}
 
-\item{n_groups}{<TODO>}
+\item{n_groups}{Number of groups of predictors}
 
-\item{n_targets}{<TODO>}
+\item{n_targets}{Dimension of response variable}
 
 \item{density}{Determine sparsity of the data generated. Default set to 0.}
 
-\item{amplitude}{<TODO>}
+\item{amplitude}{Scale of coefficient in output}
 
-\item{alpha}{<TODO>}
+\item{alpha}{Standard deviation}
 
 \item{response}{Choice of likelohood function}
 
-\item{rho}{<TODO>}
+\item{rho}{Correlation}
 }
 \description{
 Code borrowed from SLOPE package for generating datasets

--- a/src/ADMM.cpp
+++ b/src/ADMM.cpp
@@ -40,6 +40,7 @@ List cppADMM(T& x, mat& y, const List control)
   auto tol_infeas  = as<double>(control["tol_infeas"]);
   auto tol_abs     = as<double>(control["tol_abs"]);
   auto tol_rel     = as<double>(control["tol_rel"]);
+  auto tol         = as<double>(control["tol"]);
 
   auto family_choice = as<std::string>(control["family"]);
   auto intercept     = as<bool>(control["fit_intercept"]);
@@ -90,6 +91,7 @@ List cppADMM(T& x, mat& y, const List control)
                             tol_infeas,
                             tol_abs,
                             tol_rel,
+                            tol,
                             verbosity);
 
   cube betas(p, m, path_length, fill::zeros);

--- a/src/ADMM.cpp
+++ b/src/ADMM.cpp
@@ -40,7 +40,7 @@ List cppADMM(T& x, mat& y, const List control)
   auto tol_infeas  = as<double>(control["tol_infeas"]);
   auto tol_abs     = as<double>(control["tol_abs"]);
   auto tol_rel     = as<double>(control["tol_rel"]);
-  auto tol         = as<double>(control["tol"]);
+  auto tol_coef    = as<double>(control["tol_coef"]);
 
   auto family_choice = as<std::string>(control["family"]);
   auto intercept     = as<bool>(control["fit_intercept"]);
@@ -91,7 +91,7 @@ List cppADMM(T& x, mat& y, const List control)
                             tol_infeas,
                             tol_abs,
                             tol_rel,
-                            tol,
+                            tol_coef,
                             verbosity);
 
   cube betas(p, m, path_length, fill::zeros);

--- a/src/FISTA.cpp
+++ b/src/FISTA.cpp
@@ -38,6 +38,7 @@ List cppFISTA(T& x, mat& y, const List control)
 
   auto tol_abs     = as<double>(control["tol_abs"]);
   auto tol_rel     = as<double>(control["tol_rel"]);
+  auto tol         = as<double>(control["tol"]);
 
   auto family_choice = as<std::string>(control["family"]);
   auto intercept     = as<bool>(control["fit_intercept"]);
@@ -88,6 +89,7 @@ List cppFISTA(T& x, mat& y, const List control)
                             tol_infeas,
                             tol_abs,
                             tol_rel,
+                            tol,
                             verbosity);
 
   cube betas(p, m, path_length, fill::zeros);

--- a/src/FISTA.cpp
+++ b/src/FISTA.cpp
@@ -38,7 +38,7 @@ List cppFISTA(T& x, mat& y, const List control)
 
   auto tol_abs     = as<double>(control["tol_abs"]);
   auto tol_rel     = as<double>(control["tol_rel"]);
-  auto tol         = as<double>(control["tol"]);
+  auto tol_coef    = as<double>(control["tol_coef"]);
 
   auto family_choice = as<std::string>(control["family"]);
   auto intercept     = as<bool>(control["fit_intercept"]);
@@ -89,7 +89,7 @@ List cppFISTA(T& x, mat& y, const List control)
                             tol_infeas,
                             tol_abs,
                             tol_rel,
-                            tol,
+                            tol_coef,
                             verbosity);
 
   cube betas(p, m, path_length, fill::zeros);

--- a/src/PN.cpp
+++ b/src/PN.cpp
@@ -39,7 +39,7 @@ List cppPN(T& x, mat& y, const List control)
   auto tol_infeas   = as<double>(control["tol_infeas"]);
   auto tol_abs      = as<double>(control["tol_abs"]);
   auto tol_rel      = as<double>(control["tol_rel"]);
-  auto tol          = as<double>(control["tol"]);
+  auto tol_coef     = as<double>(control["tol_coef"]);
 
   auto family_choice = as<std::string>(control["family"]);
   auto intercept     = as<bool>(control["fit_intercept"]);
@@ -90,7 +90,7 @@ List cppPN(T& x, mat& y, const List control)
                             tol_infeas,
                             tol_abs,
                             tol_rel,
-                            tol,
+                            tol_coef,
                             verbosity);
 
   cube betas(p, m, path_length, fill::zeros);

--- a/src/PN.cpp
+++ b/src/PN.cpp
@@ -3,6 +3,7 @@
 #include "results.h"
 #include "families/families.h"
 #include "algorithms/proximal_newton.h"
+#include "algorithms/proximal_quasi_newton.h"
 #include "standardize.h"
 #include "rescale.h"
 #include "regularizationPath.h"
@@ -32,11 +33,12 @@ List cppPN(T& x, mat& y, const List control)
   auto verbosity = as<uword>(control["verbosity"]);
 
   // solver arguments
-  auto max_passes  = as<uword>(control["max_passes"]);
-  auto tol_rel_gap = as<double>(control["tol_rel_gap"]);
-  auto tol_infeas  = as<double>(control["tol_infeas"]);
-  auto tol_abs     = as<double>(control["tol_abs"]);
-  auto tol_rel     = as<double>(control["tol_rel"]);
+  auto max_passes   = as<uword>(control["max_passes"]);
+  auto hessian_calc = as<std::string>(control["hessian_calc"]);
+  auto tol_rel_gap  = as<double>(control["tol_rel_gap"]);
+  auto tol_infeas   = as<double>(control["tol_infeas"]);
+  auto tol_abs      = as<double>(control["tol_abs"]);
+  auto tol_rel      = as<double>(control["tol_rel"]);
 
   auto family_choice = as<std::string>(control["family"]);
   auto intercept     = as<bool>(control["fit_intercept"]);
@@ -116,7 +118,7 @@ List cppPN(T& x, mat& y, const List control)
 
   while (k < path_length) {
     inner_timer.tic();
-    res = family->fitProximalNewton(x, y, lambda*alpha(k));
+    res = family->fitPN(x, y, lambda*alpha(k), hessian_calc);
     passes(k) = res.passes;
     beta = res.beta;
 

--- a/src/PN.cpp
+++ b/src/PN.cpp
@@ -23,7 +23,7 @@ List cppPN(T& x, mat& y, const List control)
   using std::showpoint;
 
   // significant digits
-  Rcout.precision(4);
+  Rcout.precision(9);
 
   auto tol_dev_ratio = as<double>(control["tol_dev_ratio"]);
   auto tol_dev_change = as<double>(control["tol_dev_change"]);
@@ -39,6 +39,7 @@ List cppPN(T& x, mat& y, const List control)
   auto tol_infeas   = as<double>(control["tol_infeas"]);
   auto tol_abs      = as<double>(control["tol_abs"]);
   auto tol_rel      = as<double>(control["tol_rel"]);
+  auto tol          = as<double>(control["tol"]);
 
   auto family_choice = as<std::string>(control["family"]);
   auto intercept     = as<bool>(control["fit_intercept"]);
@@ -89,6 +90,7 @@ List cppPN(T& x, mat& y, const List control)
                             tol_infeas,
                             tol_abs,
                             tol_rel,
+                            tol,
                             verbosity);
 
   cube betas(p, m, path_length, fill::zeros);

--- a/src/algorithms/proximal_newton.h
+++ b/src/algorithms/proximal_newton.h
@@ -29,8 +29,6 @@ Results Family::fitProximalNewton(const T& x, const mat& y, vec lambda)
   const double alpha = 0.5;
   const double eta = 0.5;
 
-  const double tol = 1e-10;
-
   vec hess_correction(p, fill::ones); 
 
   // diagnostics
@@ -102,7 +100,7 @@ Results Family::fitProximalNewton(const T& x, const mat& y, vec lambda)
 
     beta += t*d;
 
-    if (norm(t*d) < tol)
+    if (norm(t*d) < tol_coef)
       break;
     
     hess_correction = abs(t*d);

--- a/src/algorithms/proximal_newton.h
+++ b/src/algorithms/proximal_newton.h
@@ -38,7 +38,7 @@ Results Family::fitProximalNewton(const T& x, const mat& y, vec lambda)
   std::vector<double> loss;
   std::vector<double> time;
 
-  if(diagnostics){
+  if (diagnostics) {
     loss.reserve(max_passes);
     time.reserve(max_passes);
     timer.tic();
@@ -70,7 +70,7 @@ Results Family::fitProximalNewton(const T& x, const mat& y, vec lambda)
     grad = gradient(x, y, lin_pred);
     hess = hessian(x, y, lin_pred);
 
-    if(rcond(hess) < 1e-16){
+    if (rcond(hess) < 1e-16) {
       hess.diag() += hess_correction;
     }
 

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -23,15 +23,6 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
   mat beta(p, m, fill::zeros);
   mat beta_tilde(beta);
 
-  mat lin_pred(n, m);
-  mat grad(p, m, fill::zeros);
-
-  // mat hess(p, p, fill::zeros);
-
-  // hess.diag() += 1;
-
-  // mat I = hess;
-
   // line search parameters
   const double alpha = 0.5;
   const double eta = 0.5;
@@ -50,9 +41,9 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
   }
 
   LBFGS lbfgs(lambda);
-  // beta(0) = -2.398615e+00;
-  lin_pred = x*beta;
-  grad = gradient(x, y, lin_pred);
+  
+  mat lin_pred = x*beta;
+  mat grad = gradient(x, y, lin_pred);
 
   // main loop
   uword passes = 0;
@@ -74,17 +65,6 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
               << ", objective: "  << obj 
               << endl;
     }
-    // Rcout << "H check" << endl;
-    // (hess-lbfgs.computeH(p)).print();
-    // Rcout << "HV check" << endl;
-    // (lbfgs.computeHv(grad)- hess*grad).print();
-    // Rcout << "----------" << endl;
-    // (lbfgs.computeHv2(grad)-hess*grad).print();
-    // Rcout << "BV check" << endl;
-    // (lbfgs.computeBv(grad)-inv(hess)*grad).print();
-    // Rcout << "----------" << endl;
-    // (lbfgs.computeBv2(grad)-solve(hess,grad)).print();
-    // Rcout << "----------" << endl;
     
 
     beta_tilde = beta - lbfgs.computeHv(grad);
@@ -92,8 +72,6 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
     beta_tilde = lbfgs.scaled_prox(beta_tilde);
     
     mat d = beta_tilde - beta;
-
-    Rcout << "d is " << d(0) << endl;
 
     // Backtracking line search
     double t = 1.0;
@@ -114,18 +92,14 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
       }
       checkUserInterrupt();
     }
-    Rcout << " QPN t is : " << t << " norm(t*d): " << norm(t*d) << endl;
+    
     beta_tilde = beta + t*d;
-    // if (intercept)
-    //   beta_tilde(0) = beta_tilde(0) - t*d(0) + d(0);
     
     lin_pred = x*beta_tilde;
 
     mat grad_new = gradient(x, y, lin_pred);
 
     if (lbfgs.updateParams(beta_tilde - beta, grad_new - grad)){
-      Rcout << "UPDATE ENDED" << endl;
-      // exit(0);
       break;
     }
 

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -40,7 +40,7 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
     timer.tic();
   }
 
-  LBFGS lbfgs(lambda);
+  LBFGS lbfgs;
   
   mat lin_pred = x*beta;
   mat grad = gradient(x, y, lin_pred);
@@ -66,19 +66,19 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
               << endl;
     }
     
-    if(!(lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).is_zero(1e-5)){
-        Rcout << "HV" << endl;
-        lbfgs.computeHv(grad).print();
-        Rcout << "-------------" << endl;
-        lbfgs.computeHv_cached(grad).print();
-        Rcout << "-------------" << endl;
-        (lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).print();
-        exit(0);
-      }
+    // if(!(lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).is_zero(1e-5)){
+    //     Rcout << "HV" << endl;
+    //     lbfgs.computeHv(grad).print();
+    //     Rcout << "-------------" << endl;
+    //     lbfgs.computeHv_cached(grad).print();
+    //     Rcout << "-------------" << endl;
+    //     (lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).print();
+    //     exit(0);
+    //   }
 
-    beta_tilde = beta - lbfgs.computeHv(grad);
+    beta_tilde = beta - lbfgs.computeHv_cached(grad);
 
-    beta_tilde = lbfgs.scaled_prox(beta_tilde);
+    beta_tilde = lbfgs.scaled_prox(beta_tilde, lambda);
     
     mat d = beta_tilde - beta;
 

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -69,13 +69,9 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
               << endl;
     }
 
-    lbfgs.computeHv(grad).print();
-
     beta_tilde = beta - lbfgs.computeHv(grad);
 
-    Rcout << "--------" << endl;
     beta_tilde = lbfgs.scaled_prox(beta_tilde);
-    beta_tilde.print();
     
     vec d = beta_tilde - beta;
 
@@ -98,7 +94,7 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
       }
       checkUserInterrupt();
     }
-
+    Rcout << " t is : " << t << endl;
     beta += t*d;
     lin_pred = x*beta;
 

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -14,7 +14,6 @@ template <typename T>
 Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
 {
   
-  uword n = y.n_rows;
   uword p = x.n_cols;
   uword m = y.n_cols;
   uword pmi = lambda.n_elem;
@@ -100,7 +99,7 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
       break;
     }
 
-    if (norm(t*d) < tol)
+    if (norm(t*d) < tol_coef)
       break;
     
     grad = grad_new;

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -66,6 +66,15 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
               << endl;
     }
     
+    if(!(lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).is_zero(1e-5)){
+        Rcout << "HV" << endl;
+        lbfgs.computeHv(grad).print();
+        Rcout << "-------------" << endl;
+        lbfgs.computeHv_cached(grad).print();
+        Rcout << "-------------" << endl;
+        (lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).print();
+        exit(0);
+      }
 
     beta_tilde = beta - lbfgs.computeHv(grad);
 

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -60,12 +60,11 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
     
     if (verbosity >= 3) {
         Rcout << "pass: "         << passes
-              << ", objective: "  << obj ;
-              // << endl;
+              << ", objective: "  << obj
+              << endl;
     }
-    
 
-    beta_tilde = beta - lbfgs.computeHv_cached(grad);
+    beta_tilde = beta - lbfgs.computeHv(grad);
 
     beta_tilde = lbfgs.scaled_prox(beta_tilde, lambda);
     
@@ -93,8 +92,6 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
     
     beta_tilde = beta + t*d;
 
-    Rcout << ", norm(td): " << norm(t*d) << endl;
-    
     lin_pred = x*beta_tilde;
 
     mat grad_new = gradient(x, y, lin_pred);

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -27,8 +27,6 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
   const double alpha = 0.5;
   const double eta = 0.5;
 
-  const double tol = 1e-10;
-
   // diagnostics
   wall_clock timer;
   std::vector<double> loss;
@@ -62,19 +60,10 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
     
     if (verbosity >= 3) {
         Rcout << "pass: "         << passes
-              << ", objective: "  << obj 
-              << endl;
+              << ", objective: "  << obj ;
+              // << endl;
     }
     
-    // if(!(lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).is_zero(1e-5)){
-    //     Rcout << "HV" << endl;
-    //     lbfgs.computeHv(grad).print();
-    //     Rcout << "-------------" << endl;
-    //     lbfgs.computeHv_cached(grad).print();
-    //     Rcout << "-------------" << endl;
-    //     (lbfgs.computeHv(grad)-lbfgs.computeHv_cached(grad)).print();
-    //     exit(0);
-    //   }
 
     beta_tilde = beta - lbfgs.computeHv_cached(grad);
 
@@ -103,6 +92,8 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
     }
     
     beta_tilde = beta + t*d;
+
+    Rcout << ", norm(td): " << norm(t*d) << endl;
     
     lin_pred = x*beta_tilde;
 

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -63,7 +63,7 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
               << endl;
     }
 
-    beta_tilde = beta - lbfgs.computeHv(grad);
+    beta_tilde = beta - lbfgs.inverseHessianProduct(grad);
 
     beta_tilde = lbfgs.scaled_prox(beta_tilde, lambda);
     

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <RcppArmadillo.h>
+#include "../results.h"
+#include "../lbfgs_utils.h"
+#include "../families/family.h"
+
+using namespace Rcpp;
+using namespace arma;
+
+// Proximal Quasi-Newton algorithm. 
+// Uses L-BFGS for Hessian approximation.
+template <typename T>
+Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
+{
+  
+  uword n = y.n_rows;
+  uword p = x.n_cols;
+  uword m = y.n_cols;
+  uword pmi = lambda.n_elem;
+  uword p_rows = pmi/m;
+
+  mat beta(p, m, fill::zeros);
+  mat beta_tilde(beta);
+
+  mat lin_pred(n, m);
+  mat grad(p, m, fill::zeros);
+
+  // line search parameters
+  const double alpha = 0.5;
+  const double eta = 0.5;
+
+  const double tol = 1e-10;
+
+  // diagnostics
+  wall_clock timer;
+  std::vector<double> loss;
+  std::vector<double> time;
+
+  if(diagnostics){
+    loss.reserve(max_passes);
+    time.reserve(max_passes);
+    timer.tic();
+  }
+
+  LBFGS lbfgs(lambda);
+
+  lin_pred = x*beta;
+  grad = gradient(x, y, lin_pred);
+
+  // main loop
+  uword passes = 0;
+  while (passes < max_passes) {
+    ++passes;
+  
+    double f = primal(y, lin_pred);
+    double g = dot(sort(abs(vectorise(beta.tail_rows(p_rows))),
+                        "descending"), lambda);
+    double obj = f + g;
+
+    if (diagnostics) {
+        loss.push_back(obj);
+        time.push_back(timer.toc());
+    }
+    
+    if (verbosity >= 3) {
+        Rcout << "pass: "         << passes
+              << ", objective: "  << obj 
+              << endl;
+    }
+
+    lbfgs.computeHv(grad).print();
+
+    beta_tilde = beta - lbfgs.computeHv(grad);
+
+    Rcout << "--------" << endl;
+    beta_tilde = lbfgs.scaled_prox(beta_tilde);
+    beta_tilde.print();
+    
+    vec d = beta_tilde - beta;
+
+    // Backtracking line search
+    double t = 1.0;
+    double dTgrad = dot(d, grad);
+    double obj_new;
+    while (true) {
+      mat beta_new = beta + t*d;
+
+      double f_new = primal(y, x*(beta_new));
+      double g_new = dot(sort(abs(vectorise(beta_new.tail_rows(p_rows))),
+                              "descending"), lambda);
+      obj_new = f_new + g_new;
+
+      if (obj + alpha*(t*dTgrad + g_new - g)  >= obj_new) {
+        break;
+      } else {
+        t *= eta;
+      }
+      checkUserInterrupt();
+    }
+
+    beta += t*d;
+    lin_pred = x*beta;
+
+    mat grad_new = gradient(x, y, lin_pred);
+
+    if (lbfgs.updateParams(t*d, grad_new - grad))
+      break;
+
+    if (norm(t*d) < tol)
+      break;
+    
+    grad = grad_new;
+
+    if (passes % 10 == 0)
+      checkUserInterrupt();
+    
+  }
+
+  double deviance = 2*primal(y, x*beta);
+
+  // res.diagnosticsLoss contains 'objective value'
+  // at index 0
+  Results res{beta,
+              passes,
+              {loss},
+              time,
+              deviance};
+
+  return res;
+}

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -32,7 +32,7 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
   std::vector<double> loss;
   std::vector<double> time;
 
-  if(diagnostics){
+  if (diagnostics) {
     loss.reserve(max_passes);
     time.reserve(max_passes);
     timer.tic();

--- a/src/algorithms/proximal_quasi_newton.h
+++ b/src/algorithms/proximal_quasi_newton.h
@@ -122,3 +122,4 @@ Results Family::fitProximalQuasiNewton(const T& x, const mat& y, vec lambda)
 
   return res;
 }
+

--- a/src/families/family.h
+++ b/src/families/family.h
@@ -15,6 +15,7 @@ protected:
   const double tol_infeas;
   const double tol_abs;
   const double tol_rel;
+  const double tol;
   const uword verbosity;
 
 
@@ -26,6 +27,7 @@ public:
          const double tol_infeas,
          const double tol_abs,
          const double tol_rel,
+         const double tol,
          const uword verbosity)
     : intercept(intercept),
       diagnostics(diagnostics),
@@ -34,6 +36,7 @@ public:
       tol_infeas(tol_infeas),
       tol_abs(tol_abs),
       tol_rel(tol_rel),
+      tol(tol),
       verbosity(verbosity) {}
 
   virtual double primal(const mat& y, const mat& lin_pred) = 0;

--- a/src/families/family.h
+++ b/src/families/family.h
@@ -15,7 +15,7 @@ protected:
   const double tol_infeas;
   const double tol_abs;
   const double tol_rel;
-  const double tol;
+  const double tol_coef;
   const uword verbosity;
 
 
@@ -27,7 +27,7 @@ public:
          const double tol_infeas,
          const double tol_abs,
          const double tol_rel,
-         const double tol,
+         const double tol_coef,
          const uword verbosity)
     : intercept(intercept),
       diagnostics(diagnostics),
@@ -36,7 +36,7 @@ public:
       tol_infeas(tol_infeas),
       tol_abs(tol_abs),
       tol_rel(tol_rel),
-      tol(tol),
+      tol_coef(tol_coef),
       verbosity(verbosity) {}
 
   virtual double primal(const mat& y, const mat& lin_pred) = 0;

--- a/src/families/family.h
+++ b/src/families/family.h
@@ -113,5 +113,16 @@ public:
 
   template <typename T>
   Results fitProximalNewton(const T& x, const mat& y, vec lambda);
+
+  template <typename T>
+  Results fitProximalQuasiNewton(const T& x, const mat& y, vec lambda);
+
+  template <typename T>
+  Results fitPN(const T& x, const mat& y, vec lambda, const std::string hessian_calc){
+    if (hessian_calc == "exact")
+      return fitProximalNewton(x, y, lambda);
+    else 
+      return fitProximalQuasiNewton(x, y, lambda);
+  }
   
 };

--- a/src/lbfgs_utils.h
+++ b/src/lbfgs_utils.h
@@ -10,20 +10,32 @@ using namespace arma;
 
 class LBFGS {
 private:
+  // Number of variable and gradient changes
+  // to be used
   const uword m = 7;
-  double gamma = 1.0;
+  // Scaling parameter of hessian
   double sigma = 1.0;
+  // Scaling parameter of inverse hessian
+  double gamma = 1.0;
   
+  // Matrix storing changes in variable
   mat S;
+  // Matrix storing changes in gradient
   mat Y;
+  // Strictly lower traingle of S.t()*Y
   mat L;
+  // Upper traingle of S.t()*Y
   mat R;
+  // Diagonal of S.t()*Y
   mat D;
 
-  mat Q_Hv;
+  // Utility matrices used in computeBv
   mat Q_Bv;
-  mat A_Hv;
   mat A_Bv;
+
+  // Utility matrices used in computeHv
+  mat Q_Hv;
+  mat A_Hv;
 
   // Scaled Proximal parameters
   const double tol_rel_gap = 1e-5;
@@ -32,7 +44,8 @@ private:
   uword max_passes = 10000;
 
 public:
-
+  // Updates S,Y,L,R,D.
+  // Returns true to terminate main PQN loop, false otherwise.
   bool updateParams(const mat& s, const mat& y) {
 
     if (dot(s, y) == 0)
@@ -48,11 +61,9 @@ public:
 
     gamma = dot(s, y)/dot(y, y);
     sigma = 1/gamma;
-    // sigma = dot(s, y)/dot(s, s);
-
-    // Rcout << "--------" << endl;
+    
     mat sTy = S.t()*Y;
-    // sTy.print();
+    
     R = trimatu(sTy);
     L = sTy - R;
     D = diagmat(sTy);
@@ -75,32 +86,8 @@ public:
 
   }
 
+  // Computes H*v, where H is inverse hessian approximation
   mat computeHv(const mat& v) {
-
-    if (S.n_cols == 0) {
-      return gamma*v;
-    }
-
-    // Rcout << " Hv main entered" << endl;
-
-    mat Rinv = inv(R);
-    mat z = vectorise(v);
-    mat Q = join_rows(S, gamma*Y);
-
-    mat ans = Q.t()*z;
-
-    mat tmp = Rinv.t()*(D + gamma*Y.t()*Y)*Rinv;
-    tmp = join_rows(tmp, -Rinv.t());
-    tmp = join_cols(tmp, join_rows(-Rinv, zeros(size(R))));
-
-    ans = tmp*ans;
-    ans = Q*ans;
-    ans = gamma*z + ans;
-
-    return reshape(ans, size(v));
-  }
-
-  mat computeHv_cached(const mat& v) {
 
     if (S.n_cols == 0) {
       return gamma*v;
@@ -110,37 +97,13 @@ public:
     ans = A_Hv*ans;
     ans = Q_Hv*ans;
     ans = gamma*v + ans;
-    return ans;
 
+    return ans;
   }
 
 
+  // Computes B*v, where B is hessian approximation
   mat computeBv(const mat& v) {
-
-    if (S.n_cols == 0) {
-      return sigma*v;
-    }
-    // Rcout << " Bv main entered" << endl;
-
-    mat z = vectorise(v);
-    mat Q = join_rows(sigma*S, Y);
-
-    mat ans = Q.t()*z;
-
-    mat tmp = sigma*S.t()*S;
-    tmp = join_rows(tmp, L);
-    tmp = join_cols(tmp, join_rows(L.t(), -D));
-
-    // ans = solve(tmp, ans);
-    ans = inv(tmp)*ans;
-    ans = Q*ans;
-    ans = sigma*z - ans;
-    
-    return ans;
-    // return reshape(ans, size(v));
-  }
-
-  mat computeBv_cached(const mat& v) {
 
     if (S.n_cols == 0) {
       return sigma*v;
@@ -150,12 +113,13 @@ public:
     ans = inv(A_Bv)*ans;
     ans = Q_Bv*ans;
     ans = sigma*v - ans;
-    return ans;
 
+    return ans;
   }
 
-
-
+  // Solvers argmin_x { 0.5*(x-beta).t()*B*(x-beta) + J(x,lambda) }
+  // where J(x,lambda) is the slope penalty and B is hessian approximation.
+  // This subproblem is solved using FISTA.
   mat scaled_prox(const mat& beta, vec lambda) {
     uword p = beta.n_rows;
     uword m = beta.n_cols;
@@ -168,17 +132,15 @@ public:
     mat x_tilde_old(x);
 
     double learning_rate = 1.0;
-
-    // line search parameters
+    
     double alpha = 0.5;
 
-    // FISTA parameter
     double t = 1;
 
     uword passes = 0;
     while (passes < max_passes) {
       
-      double g = 0.5*dot(x - beta, computeBv_cached(x - beta));
+      double g = 0.5*dot(x - beta, computeBv(x - beta));
       double h = dot(sort(abs(vectorise(x.tail_rows(p_rows))),
                           "descending"), lambda);
       double f = g + h;
@@ -200,7 +162,7 @@ public:
 
         vec d = vectorise(x_tilde - x);
 
-        g = 0.5*dot(x_tilde - beta, computeBv_cached(x_tilde - beta));
+        g = 0.5*dot(x_tilde - beta, computeBv(x_tilde - beta));
 
         double q = g_old
           + dot(d, vectorise(grad))
@@ -214,14 +176,11 @@ public:
           checkUserInterrupt();
       }
 
-      // if(learning_rate < 1e-8)
-      //   break;
-
-      // FISTA step
       t = 0.5*(1.0 + std::sqrt(1.0 + 4.0*t_old*t_old));
       x = x_tilde + (t_old - 1.0)/t * (x_tilde - x_tilde_old);
       
-      if(norm(x-x_prev) < 1e-6)
+      // Stop if change is x is small
+      if(norm(x - x_prev) < 1e-6)
         break;
       x_prev = x;
 
@@ -232,7 +191,6 @@ public:
       
     }
     
-
     return x_tilde;
 
   }

--- a/src/lbfgs_utils.h
+++ b/src/lbfgs_utils.h
@@ -29,11 +29,11 @@ private:
   // Diagonal of S.t()*Y
   mat D;
 
-  // Utility matrices used in computeBv
+  // Utility matrices used in hessianProduct
   mat Q_Bv;
   mat A_Bv;
 
-  // Utility matrices used in computeHv
+  // Utility matrices used in inverseHessianProduct
   mat Q_Hv;
   mat A_Hv;
 
@@ -87,7 +87,7 @@ public:
   }
 
   // Computes H*v, where H is inverse hessian approximation
-  mat computeHv(const mat& v) {
+  mat inverseHessianProduct(const mat& v) {
 
     if (S.n_cols == 0) {
       return gamma*v;
@@ -103,7 +103,7 @@ public:
 
 
   // Computes B*v, where B is hessian approximation
-  mat computeBv(const mat& v) {
+  mat hessianProduct(const mat& v) {
 
     if (S.n_cols == 0) {
       return sigma*v;
@@ -140,12 +140,12 @@ public:
     uword passes = 0;
     while (passes < max_passes) {
       
-      double g = 0.5*dot(x - beta, computeBv(x - beta));
+      double g = 0.5*dot(x - beta, hessianProduct(x - beta));
       double h = dot(sort(abs(vectorise(x.tail_rows(p_rows))),
                           "descending"), lambda);
       double f = g + h;
 
-      mat grad = computeBv(x - beta);
+      mat grad = hessianProduct(x - beta);
 
       x_tilde_old = x_tilde;
 
@@ -162,7 +162,7 @@ public:
 
         vec d = vectorise(x_tilde - x);
 
-        g = 0.5*dot(x_tilde - beta, computeBv(x_tilde - beta));
+        g = 0.5*dot(x_tilde - beta, hessianProduct(x_tilde - beta));
 
         double q = g_old
           + dot(d, vectorise(grad))

--- a/src/lbfgs_utils.h
+++ b/src/lbfgs_utils.h
@@ -20,11 +20,16 @@ private:
   mat R;
   mat D;
 
+  mat Q_Hv;
+  mat Q_Bv;
+  mat A_Hv;
+  mat A_Bv;
+
   // Scaled Proximal parameters
   const double tol_rel_gap = 1e-5;
   const double tol_infeas = 1e-3;
   const double tol_rel_coef_change = 1e-3;
-  uword max_passes = 5000;
+  uword max_passes = 10000;
 
 public:
   LBFGS(const vec lambda) : lambda(lambda) {}
@@ -53,6 +58,20 @@ public:
     L = sTy - R;
     D = diagmat(sTy);
 
+    Q_Hv = join_rows(S, gamma*Y);
+    Q_Bv = join_rows(sigma*S, Y);
+
+    mat tmp;
+
+    mat Rinv = inv(R);
+    tmp = Rinv.t()*(D + gamma*Y.t()*Y)*Rinv;
+    tmp = join_rows(tmp, -Rinv.t());
+    A_Hv = join_cols(tmp, join_rows(-Rinv, zeros(size(R))));
+
+    tmp = sigma*S.t()*S;
+    tmp = join_rows(tmp, L);
+    A_Bv = join_cols(tmp, join_rows(L.t(), -D));
+
     return false;
 
   }
@@ -80,6 +99,20 @@ public:
     ans = gamma*z + ans;
 
     return reshape(ans, size(v));
+  }
+
+  mat computeHv_cached(const mat& v) {
+
+    if (S.n_cols == 0) {
+      return gamma*v;
+    }
+
+    mat ans = Q_Hv.t()*v;
+    ans = A_Hv*ans;
+    ans = Q_Hv*ans;
+    ans = gamma*v + ans;
+    return ans;
+
   }
 
   // mat computeH(int p) {
@@ -155,6 +188,35 @@ public:
     // return reshape(ans, size(v));
   }
 
+  mat computeBv_cached(const mat& v) {
+
+    if (S.n_cols == 0) {
+      return sigma*v;
+    }
+
+    mat ans = Q_Bv.t()*v;
+    ans = inv(A_Bv)*ans;
+    ans = Q_Bv*ans;
+    ans = sigma*v - ans;
+    return ans;
+
+    // mat Q = join_rows(sigma*S, Y);
+
+    // mat ans = Q.t()*z;
+
+    // mat tmp = sigma*S.t()*S;
+    // tmp = join_rows(tmp, L);
+    // tmp = join_cols(tmp, join_rows(L.t(), -D));
+
+    // // ans = solve(tmp, ans);
+    // ans = inv(tmp)*ans;
+    // ans = Q*ans;
+    // ans = sigma*z - ans;
+    
+    // return ans;
+    // return reshape(ans, size(v));
+  }
+
 
 
   mat scaled_prox(const mat& beta) {
@@ -178,43 +240,24 @@ public:
 
     uword passes = 0;
     while (passes < max_passes) {
+
+      if(!(computeBv(x-beta)-computeBv_cached(x-beta)).is_zero(1e-5)){
+        Rcout << "BV" << endl;
+        computeBv(x-beta).print();
+        Rcout << "-------------" << endl;
+        computeBv_cached(x-beta).print();
+        Rcout << "-------------" << endl;
+        (computeBv(x-beta)-computeBv_cached(x-beta)).print();
+        exit(0);
+      }
       
       double g = 0.5*dot(x - beta, computeBv(x - beta));
       double h = dot(sort(abs(vectorise(x.tail_rows(p_rows))),
                           "descending"), lambda);
       double f = g + h;
-      double G = 0.5*pow(norm(beta, 2), 2) - 0.5*pow(norm(x, 2), 2);
-
-      // if (passes % 100 == 0)
-      //   Rcout << " SP: pass: " << passes << " obj: " << g << " + " << h  << " = " << g+h << endl;
 
       mat grad = computeBv(x - beta);
 
-      double infeas =
-        lambda.n_elem > 0.0 ? infeasibility(grad.tail_rows(p_rows), lambda) : 0.0;
-
-      double small = std::sqrt(datum::eps);
-
-      bool optimal =
-        (std::abs(f - G)/std::max(small, std::abs(f)) < tol_rel_gap);
-
-      bool feasible =
-        lambda.n_elem > 0.0 ? infeas <= std::max(small, tol_infeas*lambda(0))
-                            : true;
-
-      // check change in coefficients
-      double max_change = abs(vectorise(x - x_prev)).max();
-      double max_size = abs(vectorise(beta)).max();
-
-      bool all_zero  =
-        (max_size == 0.0) && (max_change == 0.0);
-      bool small_change =
-        (max_size != 0.0) && (max_change/max_size <= tol_rel_coef_change);
-
-      bool small_coef_change = all_zero || small_change;
-      
-      if (optimal && feasible && passes > 0 && small_coef_change)
-        break;
         
       x_tilde_old = x_tilde;
 
@@ -251,6 +294,9 @@ public:
       // FISTA step
       t = 0.5*(1.0 + std::sqrt(1.0 + 4.0*t_old*t_old));
       x = x_tilde + (t_old - 1.0)/t * (x_tilde - x_tilde_old);
+      
+      if(norm(x-x_prev) < 1e-6)
+        break;
       x_prev = x;
 
       if (passes % 100 == 0)
@@ -261,7 +307,7 @@ public:
     }
 
     if (p_rows != p) {
-      Rcout << " sp beta diff : " << x_tilde(0) - beta(0) << endl;
+      // Rcout << " sp beta diff : " << x_tilde(0) - beta(0) << endl;
       // x_tilde(0) = beta(0);
       // x(0) = beta(0);
     }

--- a/src/lbfgs_utils.h
+++ b/src/lbfgs_utils.h
@@ -180,7 +180,7 @@ public:
       x = x_tilde + (t_old - 1.0)/t * (x_tilde - x_tilde_old);
       
       // Stop if change is x is small
-      if(norm(x - x_prev) < 1e-6)
+      if (norm(x - x_prev) < 1e-6)
         break;
       x_prev = x;
 

--- a/src/lbfgs_utils.h
+++ b/src/lbfgs_utils.h
@@ -1,0 +1,156 @@
+#pragma once
+
+#include <RcppArmadillo.h>
+#include "prox.h"
+
+using namespace Rcpp;
+using namespace arma;
+
+
+class LBFGS {
+private:
+  const uword k = 10;
+  const vec lambda;
+  double gamma = 1.0;
+  double sigma = 1.0;
+  mat S;
+  mat Y;
+  mat L;
+  mat R;
+  mat D;
+
+  // Scaled Proximal parameters
+  const double alpha = 1.5;
+  const double rho = 1.0;
+  const double tol_abs = 1e-6;
+  const double tol_rel = 1e-5;
+  uword max_iter = 500000;
+
+public:
+  LBFGS(const vec lambda) : lambda(lambda) {}
+
+  bool updateParams(const mat& s, const mat& y) {
+
+    if (dot(s, y) == 0)
+      return true;
+    
+    S.insert_cols(S.n_cols, vectorise(s));
+    Y.insert_cols(Y.n_cols, vectorise(y));
+
+    if (S.n_cols > k) {
+      S.shed_col(0);
+      Y.shed_col(0);
+    }
+
+    gamma = dot(s, y)/dot(y, y);
+    sigma = dot(s, y)/dot(s, s);
+
+    mat sTy = S.t()*Y;
+    L = trimatl(sTy, -1);
+    R = trimatu(sTy);
+    D = diagmat(sTy);
+
+    return false;
+
+  }
+
+  mat computeHv(const mat& v) {
+
+    if (S.n_cols == 0) {
+      return gamma*v;
+    }
+
+    Rcout << " Hv main entered" << endl;
+
+    mat Rinv = inv(R);
+    mat z = vectorise(v);
+    mat Q = join_rows(S, gamma*Y);
+
+    mat ans = Q.t()*z;
+
+    mat tmp = Rinv.t()*(D + gamma*Y.t()*Y)*Rinv;
+    tmp = join_rows(tmp, -Rinv.t());
+    tmp = join_cols(tmp, join_rows(-Rinv, zeros(size(R))));
+
+    ans = tmp*ans;
+    ans = Q*ans;
+    ans = gamma*z + ans;
+
+    return reshape(ans, size(v));
+  }
+
+  mat computeBv(const mat& v) {
+
+    if (S.n_cols == 0) {
+      return sigma*v;
+    }
+    Rcout << " Bv main entered" << endl;
+
+    mat z = vectorise(v);
+    mat Q = join_rows(Y, sigma*S);
+
+    mat ans = Q.t()*z;
+
+    mat tmp = sigma*S.t()*S;
+    tmp = join_rows(tmp, L);
+    tmp = join_cols(tmp, join_rows(L.t(), -D));
+
+    ans = solve(tmp, ans);
+    ans = Q*ans;
+    ans = sigma*z - ans;
+    
+    return reshape(ans, size(v));
+  }
+
+  mat scaled_prox(const mat& beta) {
+    uword p = beta.n_rows;
+    uword m = beta.n_cols;
+    uword pmi = lambda.n_elem;
+    uword p_rows = pmi/m;
+
+    mat x(beta);
+    mat z(x);
+    mat u(x);
+
+    uword iter = 0;
+
+    mat Bbeta = computeBv(beta);
+
+    lambda.print();
+
+    while (iter < max_iter) {
+      iter++;
+      Rcout << "pass: " << iter << " SP obj: "
+            << 0.5*dot(x-beta,computeBv(x-beta)) +
+              dot(sort(abs(vectorise(beta.tail_rows(p_rows))),
+                          "descending"), lambda) << endl; 
+
+      x = beta + z - u + Bbeta/rho + rho*computeHv(z - u);
+      
+      mat z_old = z;
+      mat x_hat = alpha*x + (1 - alpha)*z_old;
+
+      z = x_hat + u;
+
+      z.tail_rows(p_rows) = prox(z.tail_rows(p_rows), lambda/rho);
+
+      u += (x_hat-z);
+
+      double r_norm = norm(x - z);
+      double s_norm = norm(rho*(z - z_old));
+
+      double eps_primal = std::sqrt(p)*tol_abs + tol_rel*std::max(norm(x), norm(z));
+      double eps_dual = std::sqrt(p)*tol_abs + tol_rel*norm(rho*u);
+
+      if (r_norm < eps_primal && s_norm < eps_dual)
+          break;
+
+      if (iter % 1000 == 0)
+        Rcpp::checkUserInterrupt();
+    }
+    
+    return x;
+  }
+
+
+};

--- a/src/lbfgs_utils.h
+++ b/src/lbfgs_utils.h
@@ -10,7 +10,7 @@ using namespace arma;
 
 class LBFGS {
 private:
-  const uword m = 30;
+  const uword m = 15;
   const vec lambda;
   double gamma = 1.0;
   double sigma = 1.0;
@@ -21,11 +21,10 @@ private:
   mat D;
 
   // Scaled Proximal parameters
-  const double alpha = 1.5;
-  const double rho = 0.1;
-  const double tol_abs = 1e-6;
-  const double tol_rel = 1e-5;
-  uword max_iter = 5000;
+  const double tol_rel_gap = 1e-5;
+  const double tol_infeas = 1e-3;
+  const double tol_rel_coef_change = 1e-3;
+  uword max_passes = 5000;
 
 public:
   LBFGS(const vec lambda) : lambda(lambda) {}
@@ -43,8 +42,8 @@ public:
       Y.shed_col(0);
     }
 
-    // gamma = dot(s, y)/dot(y, y);
-    // sigma = 1/gamma;
+    gamma = dot(s, y)/dot(y, y);
+    sigma = 1/gamma;
     // sigma = dot(s, y)/dot(s, s);
 
     // Rcout << "--------" << endl;
@@ -83,55 +82,53 @@ public:
     return reshape(ans, size(v));
   }
 
-  mat computeH(int p) {
-    mat I(p, p, fill::zeros);
-    I.diag() += 1;
+  // mat computeH(int p) {
+  //   mat I(p, p, fill::zeros);
+  //   I.diag() += 1;
 
-    if (S.n_cols == 0) {
-      return gamma*I;
-    }
+  //   if (S.n_cols == 0) {
+  //     return gamma*I;
+  //   }
 
-    mat Q = join_rows(S, gamma*Y);
-    mat ans = Q.t();
+  //   mat Q = join_rows(S, gamma*Y);
+  //   mat ans = Q.t();
 
-    mat Rinv = inv(R);
-    mat tmp = Rinv.t()*(D + gamma*Y.t()*Y)*Rinv;
-    tmp = join_rows(tmp, -Rinv.t());
-    tmp = join_cols(tmp, join_rows(-Rinv, zeros(size(R))));
+  //   mat Rinv = inv(R);
+  //   mat tmp = Rinv.t()*(D + gamma*Y.t()*Y)*Rinv;
+  //   tmp = join_rows(tmp, -Rinv.t());
+  //   tmp = join_cols(tmp, join_rows(-Rinv, zeros(size(R))));
 
-    tmp = tmp*ans;
-    tmp = Q*tmp;
+  //   tmp = tmp*ans;
+  //   tmp = Q*tmp;
 
-    return gamma*I + tmp;
+  //   return gamma*I + tmp;
     
-  }
+  // }
 
-  mat computeHv2(const mat& v) {
+  // mat computeHv2(const mat& v) {
 
-    int l = m;
+  //   int l = m;
 
-    mat q = v;
+  //   mat q = v;
 
-    double alpha[l];
-    for (int j = std::min((int)S.n_cols, l)-1; j >= 0; j--) {
-      alpha[j] = (1/dot(S.col(j),Y.col(j)))*dot(S.col(j), q);
-      q = q - alpha[j]*Y.col(j);
-    }
+  //   double alpha[l];
+  //   for (int j = std::min((int)S.n_cols, l)-1; j >= 0; j--) {
+  //     alpha[j] = (1/dot(S.col(j),Y.col(j)))*dot(S.col(j), q);
+  //     q = q - alpha[j]*Y.col(j);
+  //   }
 
-    q = gamma*q;
+  //   q = gamma*q;
 
-    for (int j = 0; j < std::min((int)S.n_cols, l); j++) {
-      q += S.col(j)*(alpha[j]-(1/dot(S.col(j),Y.col(j)))*dot(Y.col(j), q));
-    }
-    // Two Loop recursion ends
+  //   for (int j = 0; j < std::min((int)S.n_cols, l); j++) {
+  //     q += S.col(j)*(alpha[j]-(1/dot(S.col(j),Y.col(j)))*dot(Y.col(j), q));
+  //   }
+  //   // Two Loop recursion ends
 
-    return q;
+  //   return q;
 
     
-  }
+  // }
 
-
-  //////////  THIS IS CORRECT!!!!!!!!!!!!!
 
   mat computeBv(const mat& v) {
 
@@ -160,35 +157,6 @@ public:
 
 
 
-  //////////THIS IS INCORRECT
-
-  mat computeBv2(const mat& v) {
-
-    if (S.n_cols == 0) {
-      return sigma*v;
-    }
-    // Rcout << " Bv main entered" << endl;
-
-    // mat z = vectorise(v);
-    // mat Q = join_rows(Y, sigma*S);
-
-    // mat ans = Q.t()*z;
-
-    // mat J = chol(sigma*S.t()*S + L*solve(D,L.t()),"lower");
-    // mat tmp = sqrt(D);
-    // tmp = join_rows(tmp, zeros(size(D)));
-    // tmp = join_cols(tmp, join_rows(-L*inv(sqrt(D)), J));
-
-    // ans = solve(tmp, ans);
-    // ans = solve(tmp.t(),ans);
-    // ans = Q*ans;
-    // ans = sigma*z - ans;
-    
-    // return ans;
-    return v;
-    // return reshape(ans, size(v));
-  }
-
   mat scaled_prox(const mat& beta) {
     uword p = beta.n_rows;
     uword m = beta.n_cols;
@@ -196,6 +164,7 @@ public:
     uword p_rows = pmi/m;
 
     mat x(beta);
+    mat x_prev(x);
     mat x_tilde(x);
     mat x_tilde_old(x);
 
@@ -204,33 +173,49 @@ public:
     // line search parameters
     double alpha = 0.5;
 
-    // FISTA parameters
+    // FISTA parameter
     double t = 1;
 
-    // Rcout << "SP begins" << endl;
-
     uword passes = 0;
-    while (passes < max_iter) {
+    while (passes < max_passes) {
       
       double g = 0.5*dot(x - beta, computeBv(x - beta));
       double h = dot(sort(abs(vectorise(x.tail_rows(p_rows))),
                           "descending"), lambda);
       double f = g + h;
-      // double G = 
+      double G = 0.5*pow(norm(beta, 2), 2) - 0.5*pow(norm(x, 2), 2);
 
       // if (passes % 100 == 0)
       //   Rcout << " SP: pass: " << passes << " obj: " << g << " + " << h  << " = " << g+h << endl;
 
       mat grad = computeBv(x - beta);
 
+      double infeas =
+        lambda.n_elem > 0.0 ? infeasibility(grad.tail_rows(p_rows), lambda) : 0.0;
 
-      // double infeas =
-      //   lambda.n_elem > 0.0 ? infeasibility(grad.tail_rows(p_rows), lambda) : 0.0;
+      double small = std::sqrt(datum::eps);
 
+      bool optimal =
+        (std::abs(f - G)/std::max(small, std::abs(f)) < tol_rel_gap);
 
+      bool feasible =
+        lambda.n_elem > 0.0 ? infeas <= std::max(small, tol_infeas*lambda(0))
+                            : true;
 
-      // grad = x - beta;
+      // check change in coefficients
+      double max_change = abs(vectorise(x - x_prev)).max();
+      double max_size = abs(vectorise(beta)).max();
 
+      bool all_zero  =
+        (max_size == 0.0) && (max_change == 0.0);
+      bool small_change =
+        (max_size != 0.0) && (max_change/max_size <= tol_rel_coef_change);
+
+      bool small_coef_change = all_zero || small_change;
+      
+      if (optimal && feasible && passes > 0 && small_coef_change)
+        break;
+        
       x_tilde_old = x_tilde;
 
       double g_old = g;
@@ -266,6 +251,7 @@ public:
       // FISTA step
       t = 0.5*(1.0 + std::sqrt(1.0 + 4.0*t_old*t_old));
       x = x_tilde + (t_old - 1.0)/t * (x_tilde - x_tilde_old);
+      x_prev = x;
 
       if (passes % 100 == 0)
         checkUserInterrupt();
@@ -279,8 +265,7 @@ public:
       // x_tilde(0) = beta(0);
       // x(0) = beta(0);
     }
-    // Rcout << "SP ends" << endl;
-
+    Rcout << "SP passes : " << passes  << endl;
 
     return x_tilde;
 

--- a/src/lbfgs_utils.h
+++ b/src/lbfgs_utils.h
@@ -10,10 +10,10 @@ using namespace arma;
 
 class LBFGS {
 private:
-  const uword m = 15;
-  const vec lambda;
+  const uword m = 7;
   double gamma = 1.0;
   double sigma = 1.0;
+  
   mat S;
   mat Y;
   mat L;
@@ -32,7 +32,6 @@ private:
   uword max_passes = 10000;
 
 public:
-  LBFGS(const vec lambda) : lambda(lambda) {}
 
   bool updateParams(const mat& s, const mat& y) {
 
@@ -115,53 +114,6 @@ public:
 
   }
 
-  // mat computeH(int p) {
-  //   mat I(p, p, fill::zeros);
-  //   I.diag() += 1;
-
-  //   if (S.n_cols == 0) {
-  //     return gamma*I;
-  //   }
-
-  //   mat Q = join_rows(S, gamma*Y);
-  //   mat ans = Q.t();
-
-  //   mat Rinv = inv(R);
-  //   mat tmp = Rinv.t()*(D + gamma*Y.t()*Y)*Rinv;
-  //   tmp = join_rows(tmp, -Rinv.t());
-  //   tmp = join_cols(tmp, join_rows(-Rinv, zeros(size(R))));
-
-  //   tmp = tmp*ans;
-  //   tmp = Q*tmp;
-
-  //   return gamma*I + tmp;
-    
-  // }
-
-  // mat computeHv2(const mat& v) {
-
-  //   int l = m;
-
-  //   mat q = v;
-
-  //   double alpha[l];
-  //   for (int j = std::min((int)S.n_cols, l)-1; j >= 0; j--) {
-  //     alpha[j] = (1/dot(S.col(j),Y.col(j)))*dot(S.col(j), q);
-  //     q = q - alpha[j]*Y.col(j);
-  //   }
-
-  //   q = gamma*q;
-
-  //   for (int j = 0; j < std::min((int)S.n_cols, l); j++) {
-  //     q += S.col(j)*(alpha[j]-(1/dot(S.col(j),Y.col(j)))*dot(Y.col(j), q));
-  //   }
-  //   // Two Loop recursion ends
-
-  //   return q;
-
-    
-  // }
-
 
   mat computeBv(const mat& v) {
 
@@ -200,26 +152,11 @@ public:
     ans = sigma*v - ans;
     return ans;
 
-    // mat Q = join_rows(sigma*S, Y);
-
-    // mat ans = Q.t()*z;
-
-    // mat tmp = sigma*S.t()*S;
-    // tmp = join_rows(tmp, L);
-    // tmp = join_cols(tmp, join_rows(L.t(), -D));
-
-    // // ans = solve(tmp, ans);
-    // ans = inv(tmp)*ans;
-    // ans = Q*ans;
-    // ans = sigma*z - ans;
-    
-    // return ans;
-    // return reshape(ans, size(v));
   }
 
 
 
-  mat scaled_prox(const mat& beta) {
+  mat scaled_prox(const mat& beta, vec lambda) {
     uword p = beta.n_rows;
     uword m = beta.n_cols;
     uword pmi = lambda.n_elem;
@@ -240,25 +177,14 @@ public:
 
     uword passes = 0;
     while (passes < max_passes) {
-
-      if(!(computeBv(x-beta)-computeBv_cached(x-beta)).is_zero(1e-5)){
-        Rcout << "BV" << endl;
-        computeBv(x-beta).print();
-        Rcout << "-------------" << endl;
-        computeBv_cached(x-beta).print();
-        Rcout << "-------------" << endl;
-        (computeBv(x-beta)-computeBv_cached(x-beta)).print();
-        exit(0);
-      }
       
-      double g = 0.5*dot(x - beta, computeBv(x - beta));
+      double g = 0.5*dot(x - beta, computeBv_cached(x - beta));
       double h = dot(sort(abs(vectorise(x.tail_rows(p_rows))),
                           "descending"), lambda);
       double f = g + h;
 
       mat grad = computeBv(x - beta);
 
-        
       x_tilde_old = x_tilde;
 
       double g_old = g;
@@ -274,7 +200,7 @@ public:
 
         vec d = vectorise(x_tilde - x);
 
-        g = 0.5*dot(x_tilde - beta, computeBv(x_tilde - beta));
+        g = 0.5*dot(x_tilde - beta, computeBv_cached(x_tilde - beta));
 
         double q = g_old
           + dot(d, vectorise(grad))
@@ -305,13 +231,7 @@ public:
       ++passes;
       
     }
-
-    if (p_rows != p) {
-      // Rcout << " sp beta diff : " << x_tilde(0) - beta(0) << endl;
-      // x_tilde(0) = beta(0);
-      // x(0) = beta(0);
-    }
-    Rcout << "SP passes : " << passes  << endl;
+    
 
     return x_tilde;
 
@@ -320,3 +240,4 @@ public:
 
 
 };
+

--- a/tests/testthat/test-pn.R
+++ b/tests/testthat/test-pn.R
@@ -8,7 +8,7 @@ test_that("Proximal Newton: gaussian, n>p case", {
   d <- solvers::randomProblem(n, p, response="gaussian", density = 0.5)
   
   admm_solvers <- ADMM(d$x, d$y, family="gaussian", alpha=c(1.0,0.005), opt_algo="nr")
-  pn_solvers <- PN(d$x, d$y, family="gaussian", alpha=c(1.0,0.005))
+  pn_solvers <- PN(d$x, d$y, family="gaussian", alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
 })
@@ -24,7 +24,7 @@ test_that("Proximal Newton: gaussian, n<p case", {
   d <- solvers::randomProblem(n, p, response="gaussian", density = 0.5)
   
   admm_solvers <- ADMM(d$x, d$y, family="gaussian",alpha=c(1.0,0.005),opt_algo="nr")
-  pn_solvers <- PN(d$x, d$y, family="gaussian",alpha=c(1.0,0.005))
+  pn_solvers <- PN(d$x, d$y, family="gaussian",alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
 })
@@ -40,7 +40,7 @@ test_that("Proximal Newton: binomial, n>p case", {
   d <- solvers::randomProblem(n, p, response="binomial", density = 0.5)
   
   admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr")
-  pn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005))
+  pn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
 })
@@ -73,7 +73,7 @@ test_that("Proximal Newton: poisson, n>p case", {
   d <- solvers::randomProblem(n, p, response="poisson", density = 0.5)
   
   admm_solvers <- ADMM(d$x, d$y, family="poisson",alpha=c(1.0,0.005),opt_algo="nr")
-  pn_solvers <- PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005))
+  pn_solvers <- PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
 })
@@ -89,7 +89,7 @@ test_that("Proximal Newton: poisson, n<p case", {
   d <- solvers::randomProblem(n, p, response="poisson", density = 0.5)
   
   admm_solvers <- ADMM(d$x, d$y, family="poisson",alpha=c(1.0,0.005),opt_algo="nr")
-  pn_solvers <- PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005))
+  pn_solvers <- PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
 })

--- a/tests/testthat/test-pn.R
+++ b/tests/testthat/test-pn.R
@@ -56,7 +56,7 @@ test_that("Proximal Newton: binomial, n<p case", {
 
   d <- solvers::randomProblem(n, p, response="binomial", density = 0.5)
   
-  admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr",tol_abs=1e-6)
+  admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr")
   pn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 

--- a/tests/testthat/test-pn.R
+++ b/tests/testthat/test-pn.R
@@ -57,7 +57,7 @@ test_that("Proximal Newton: binomial, n<p case", {
   d <- solvers::randomProblem(n, p, response="binomial", density = 0.5)
   
   admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr",tol_abs=1e-6)
-  pn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005))
+  pn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
 })

--- a/tests/testthat/test-pn.R
+++ b/tests/testthat/test-pn.R
@@ -56,7 +56,7 @@ test_that("Proximal Newton: binomial, n<p case", {
 
   d <- solvers::randomProblem(n, p, response="binomial", density = 0.5)
   
-  admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr")
+  admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr",tol_abs=0,tol_rel=0,max_passes=10000)
   pn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005),hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 

--- a/tests/testthat/test-pn_large.R
+++ b/tests/testthat/test-pn_large.R
@@ -3,16 +3,16 @@ test_that("Proximal Newton works same as ADMM", {
   library(SLOPE)
 
   admm_solvers <- ADMM(bodyfat$x, bodyfat$y, family="gaussian", opt_algo = "nr")
-  pn_solvers <- PN(bodyfat$x, bodyfat$y, family="gaussian")
+  pn_solvers <- PN(bodyfat$x, bodyfat$y, family="gaussian",hessian_calc="exact")
   
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
   admm_solvers <- ADMM(heart$x, heart$y, family="binomial", opt_algo="nr")
-  pn_solvers <- PN(heart$x, heart$y, family="binomial")
+  pn_solvers <- PN(heart$x, heart$y, family="binomial",hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 
   admm_solvers <- ADMM(abalone$x, abalone$y, family="poisson", opt_algo = "nr")
-  pn_solvers <- PN(abalone$x, abalone$y, family="poisson")
+  pn_solvers <- PN(abalone$x, abalone$y, family="poisson",hessian_calc="exact")
   expect_equivalent(coef(admm_solvers), coef(pn_solvers), tol = 1e-2)
 })
 

--- a/tests/testthat/test-pqn.R
+++ b/tests/testthat/test-pqn.R
@@ -1,0 +1,95 @@
+test_that("Proximal Quasi-Newton: gaussian, n>p case", {
+  library(SLOPE)
+  set.seed(1)
+
+  n = 100
+  p = 10
+
+  d <- solvers::randomProblem(n, p, response="gaussian", density = 0.5)
+  
+  admm_solvers <- ADMM(d$x, d$y, family="gaussian", alpha=c(1.0,0.005), opt_algo="nr")
+  pqn_solvers <- PN(d$x, d$y, family="gaussian", alpha=c(1.0,0.005), hessian_calc="lbfgs")
+  expect_equivalent(coef(admm_solvers), coef(pqn_solvers), tol = 1e-2)
+
+})
+
+test_that("Proximal Quasi-Newton: gaussian, n<p case", {
+
+  library(SLOPE)
+  set.seed(1)
+
+  n = 10
+  p = 20
+
+  d <- solvers::randomProblem(n, p, response="gaussian", density = 0.5)
+  
+  admm_solvers <- ADMM(d$x, d$y, family="gaussian",alpha=c(1.0,0.005),opt_algo="nr")
+  pqn_solvers <- PN(d$x, d$y, family="gaussian",alpha=c(1.0,0.005), hessian_calc="lbfgs")
+  expect_equivalent(coef(admm_solvers), coef(pqn_solvers), tol = 1e-2)
+
+})
+
+test_that("Proximal Quasi-Newton: binomial, n>p case", {
+  
+  library(SLOPE)
+  set.seed(1)
+
+  n = 100
+  p = 10
+
+  d <- solvers::randomProblem(n, p, response="binomial", density = 0.5)
+  
+  admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr")
+  pqn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005), hessian_calc="lbfgs")
+  expect_equivalent(coef(admm_solvers), coef(pqn_solvers), tol = 1e-2)
+
+})
+
+
+test_that("Proximal Quasi-Newton: binomial, n<p case", {
+  library(SLOPE)
+  set.seed(1)
+
+  n = 10
+  p = 20
+
+  d <- solvers::randomProblem(n, p, response="binomial", density = 0.5)
+  
+  admm_solvers <- ADMM(d$x, d$y, family="binomial",alpha=c(1.0,0.005),opt_algo="nr", tol_abs=0,tol_rel=0,max_passes=10000)
+  pqn_solvers <- PN(d$x, d$y, family="binomial",alpha=c(1.0,0.005), hessian_calc="lbfgs")
+  expect_equivalent(coef(admm_solvers), coef(pqn_solvers), tol = 1e-2)
+
+})
+
+test_that("Proximal Quasi-Newton: poisson, n>p case", {
+
+  library(SLOPE)
+  set.seed(1)
+
+  n = 100
+  p = 10
+
+  d <- solvers::randomProblem(n, p, response="poisson", density = 0.5)
+  
+  admm_solvers <- ADMM(d$x, d$y, family="poisson",alpha=c(1.0,0.005),opt_algo="nr")
+  pqn_solvers <- PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005), hessian_calc="lbfgs")
+  expect_equivalent(coef(admm_solvers), coef(pqn_solvers), tol = 1e-2)
+
+})
+
+test_that("Proximal Quasi-Newton: poisson, n<p case", {
+
+  library(SLOPE)
+  set.seed(1)
+
+  n = 10
+  p = 20
+
+  d <- solvers::randomProblem(n, p, response="poisson", density = 0.5)
+  
+  admm_solvers <- ADMM(d$x, d$y, family="poisson",alpha=c(1.0,0.005),opt_algo="nr")
+  pqn_solvers <- PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005), hessian_calc="lbfgs")
+  expect_equivalent(coef(admm_solvers), coef(pqn_solvers), tol = 1e-2)
+
+})
+

--- a/tests/testthat/test-pqn.R
+++ b/tests/testthat/test-pqn.R
@@ -88,6 +88,7 @@ test_that("Proximal Quasi-Newton: poisson, n<p case", {
   d <- solvers::randomProblem(n, p, response="poisson", density = 0.5)
   
   admm_solvers <- ADMM(d$x, d$y, family="poisson",alpha=c(1.0,0.005),opt_algo="nr")
+  # Passes if call is : PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005), hessian_calc="lbfgs",tol=0, max_passes=550)
   pqn_solvers <- PN(d$x, d$y, family="poisson",alpha=c(1.0,0.005), hessian_calc="lbfgs")
   expect_equivalent(coef(admm_solvers), coef(pqn_solvers), tol = 1e-2)
 

--- a/tests/testthat/test-pqn_large.R
+++ b/tests/testthat/test-pqn_large.R
@@ -1,0 +1,19 @@
+test_that("Proximal Newton works same as ADMM", {
+  skip('Takes too much time')
+  library(SLOPE)
+
+  pn_solvers <- PN(bodyfat$x, bodyfat$y, family="gaussian",hessian_calc="exact")
+  pqn_solvers <- PN(bodyfat$x, bodyfat$y, family="gaussian",hessian_calc="lbfgs")
+  
+  expect_equivalent(coef(pn_solvers),coef(pqn_solvers), tol = 1e-2)
+
+  pn_solvers <- PN(heart$x, heart$y, family="binomial",hessian_calc="exact")
+  pqn_solvers <- PN(heart$x, heart$y, family="binomial",hessian_calc="lbfgs")
+  expect_equivalent(coef(pn_solvers),coef(pqn_solvers), tol = 1e-2)
+
+  pn_solvers <- PN(abalone$x, abalone$y, family="poisson",hessian_calc="exact")
+  pqn_solvers <- PN(abalone$x, abalone$y, family="poisson",hessian_calc="lbfgs")
+  expect_equivalent(coef(pn_solvers),coef(pqn_solvers), tol = 1e-2)
+})
+
+

--- a/tests/testthat/test-pqn_large.R
+++ b/tests/testthat/test-pqn_large.R
@@ -1,5 +1,5 @@
 test_that("Proximal Newton works same as ADMM", {
-  # skip('Takes too much time')
+  skip('Takes too much time')
   library(SLOPE)
 
   pn_solvers <- PN(bodyfat$x, bodyfat$y, family="gaussian",hessian_calc="exact")

--- a/tests/testthat/test-pqn_large.R
+++ b/tests/testthat/test-pqn_large.R
@@ -1,5 +1,5 @@
 test_that("Proximal Newton works same as ADMM", {
-  skip('Takes too much time')
+  # skip('Takes too much time')
   library(SLOPE)
 
   pn_solvers <- PN(bodyfat$x, bodyfat$y, family="gaussian",hessian_calc="exact")


### PR DESCRIPTION
Couple of things:

1. Main reference for L-BFGS updates I used is [here](http://users.iems.northwestern.edu/~nocedal/PDFfiles/representations.pdf). In the code, B stands for hessian approximation and H stands for inverse hessian approximation.
2. For updating L,R,D, paper proposes some efficient ways but I think bottle neck is scaled proximal rather than updation of these.
3. Paper uses sigma = dot(s, y)/dot(s, s). This did work well in practice so I used sigma = 1/gamma = dot(y, y)/dot(s, y).
4. I created a separate class named LBFGS in file `lbfgs_utils.h` to abstract out lbfgs parts from main loop.
5. Scaled Proximal currently uses change in L2 norm of x as stopping criteria. I tried using duality-gap based stopping criteria but that didn't work well (I suspect my dual calculation was wrong. I calculated it to be dot(B*(x-beta), x-beta) ).
6. If you observe, scaled proximal objective is smooth with respect to intercept term. So I tried setting x(0) = beta(0) which is the optimal solution w.r.t intercept at the end. This did not work well which seems counter intuitive to me.
7. Test at Line number 80 fails right now but if `tol=0` and `max_passes=550` then it passes. So I am not sure if `norm(x_k - x_{k-1})<tol` is the right stopping criteria.
8. Function names in LBFGS class could use some better names - need suggestions for this.
